### PR TITLE
Highlight missing info and fix update form

### DIFF
--- a/src/member/forms.py
+++ b/src/member/forms.py
@@ -375,7 +375,7 @@ class ClientScheduledStatusForm(forms.ModelForm):
 
 def load_initial_data(client):
     """
-    Load initial for the given step and client.
+    Load initial for the given client.
     """
     initial = {
         'firstname': client.member.firstname,
@@ -394,9 +394,18 @@ def load_initial_data(client):
         'latitude': client.member.address.latitude,
         'longitude': client.member.address.longitude,
         'distance': client.member.address.distance,
-        'work_information': client.client_referent.get().work_information,
-        'referral_reason': client.client_referent.get().referral_reason,
-        'date': client.client_referent.get().date,
+        'work_information':
+            client.client_referent.get().work_information
+            if client.client_referent.count()
+            else '',
+        'referral_reason':
+            client.client_referent.get().referral_reason
+            if client.client_referent.count()
+            else '',
+        'date':
+            client.client_referent.get().date
+            if client.client_referent.count()
+            else '',
         'member': client.id,
         'same_as_client': True,
         'facturation': '',

--- a/src/member/templates/client/partials/menu.html
+++ b/src/member/templates/client/partials/menu.html
@@ -6,7 +6,7 @@
       <a class="{% if active_tab == 'information' %}active{% endif %} item" href="{% url 'member:client_information' pk=client.id %}"><i class="user icon"></i>{% trans 'Personal' %}</a>
       {% if client.client_referent.all.count %}
       <a class="{% if active_tab == 'referent' %}active{% endif %} item" href="{% url 'member:client_referent' pk=client.id %}"><i class="treatment icon"></i>{% trans 'Referent' %}</a>
-      {% else %}<span class="item">{% trans 'No referent available' %}</span>{% endif %}
+      {% else %}<em><a class="item" alt="{% trans 'Add a referent' %} "href="{% url 'member:member_update_referent_information' client_id=client.id %}"><i class="warning sign orange icon"></i>{% trans 'No referent available' %}</a></em>{% endif %}
       <a class="{% if active_tab == 'billing' %}active{% endif %} item" href="{% url 'member:client_payment' pk=client.id %}"><i class="payment icon"></i>{% trans 'Billing' %}</a>
       <a class="{% if active_tab == 'status' %}active{% endif %} item" href="{% url 'member:client_status' pk=client.id %}"><i class="history icon"></i>{% trans 'Status' %}</a>
     </div>


### PR DESCRIPTION
_Fixes #380 ._
### Changes proposed in this pull request:
- Display the message as a link to the update form
- Add warning icon and formatting
- Fix the load_initial_data function to display the update form
### Status
- [X] READY
### Deployment notes and migration

The update form, step Referent information, still don't save properly, but it can be displayed without error now if referent information is none.

@savoirfairelinux/mll

Issue #380
